### PR TITLE
Fix BGP4 on no bgp

### DIFF
--- a/src/sonic_ax_impl/lib/vtysh_helper.py
+++ b/src/sonic_ax_impl/lib/vtysh_helper.py
@@ -23,7 +23,7 @@ def vtysh_run(command):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((HOST, PORT))
 
-    cmd = b"zebra\r\n" + command.encode() + b"\r\nexit\r\n"
+    cmd = b"zebra\n" + command.encode() + b"\nexit\n"
     s.send(cmd)
 
     acc = b""
@@ -58,6 +58,8 @@ def parse_bgp_summary(summ):
         l = ls[li]
         if l.startswith('Neighbor        '): break
         if l.startswith('No IPv'): # eg. No IPv6 neighbor is configured
+            return bgpinfo
+        if l.endswith('> exit'): # last command in the lines
             return bgpinfo
         li += 1
 

--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -7,7 +7,8 @@ from ax_interface.mib import MIBEntry
 class BgpSessionUpdater(MIBUpdater):
     def __init__(self):
         super().__init__()
-        self.update_data()
+        self.session_status_map = {}
+        self.session_status_list = []
 
     def update_data(self):
         self.session_status_map = {}

--- a/tests/mock_tables/bgpsummary_ipv6_nobgp.txt
+++ b/tests/mock_tables/bgpsummary_ipv6_nobgp.txt
@@ -1,0 +1,4 @@
+Hello, this is Quagga (version 0.99.24.1).                                                                                                                            Copyright 1996-2005 Kunihiro Ishiguro, et al.                                                                                                                                                                                                                                                                                                                                                                                                                                                                     User Access Verification                                                                                                                                              
+"Password:
+str-msn2700-03> show ipv6 bgp summary
+str-msn2700-03> exit

--- a/tests/mock_tables/socket.py
+++ b/tests/mock_tables/socket.py
@@ -13,30 +13,28 @@ _socket_class = socket.socket
 
 # Monkey patch
 class MockSocket(_socket_class):
-    _instance_count = 0
 
     def __init__(self, *args, **kwargs):
         super(MockSocket, self).__init__(*args, **kwargs)
-        MockSocket._instance_count %= 2
-        MockSocket._instance_count += 1
-        self.first = True
+        self._string_sent = b''
 
     def connect(self, *args, **kwargs):
         pass
 
     def send(self, *args, **kwargs):
+        string = args[0]
+        self._string_sent = string
         pass
 
     def recv(self, *args, **kwargs):
-        if not self.first:
-            return None
-        self.first = False
-
-        if MockSocket._instance_count == 1:
+        if b'show ip bgp summary' in self._string_sent:
             filename = INPUT_DIR + '/bgpsummary_ipv4.txt'
-        elif MockSocket._instance_count == 2:
+        elif b'show ipv6 bgp summary' in self._string_sent:
             filename = INPUT_DIR + '/bgpsummary_ipv6.txt'
+        else:
+            return None
 
+        self._string_sent = b''
         ret = namedtuple('ret', ['returncode', 'stdout'])
         ret.returncode = 0
         with open(filename, 'rb') as f:

--- a/tests/test_vtysh.py
+++ b/tests/test_vtysh.py
@@ -15,11 +15,14 @@ from ax_interface.encodings import ObjectIdentifier
 from ax_interface.constants import PduTypes
 from sonic_ax_impl.mibs.ietf import rfc4363
 from sonic_ax_impl.main import SonicMIB
+from sonic_ax_impl.lib.vtysh_helper import parse_bgp_summary
 
 class TestSonicMIB(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.lut = MIBTable(SonicMIB)
+        for updater in cls.lut.updater_instances:
+            updater.update_data()
 
     def test_getpdu_established(self):
         oid = ObjectIdentifier(20, 0, 0, 0, (1, 3, 6, 1, 4, 1, 9, 9, 187, 1, 2, 5, 1, 3, 1, 4, 10, 0, 0, 61))
@@ -98,3 +101,10 @@ class TestSonicMIB(TestCase):
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(oid))
         self.assertEqual(value0.data, 6)
+
+    def parse_no_bgp():
+        filename = 'bgpsummary_ipv6_nobgp.txt'
+        with open(filename, 'rb') as f:
+            bgpsu = f.read()
+        bgpsumm_ipv6 = parse_bgp_summary(bgpsu)
+        self.assertEqual(bgpsumm_ipv6, [])


### PR DESCRIPTION
Tested in this scenario:
1. start bgp docker
2. shutdown bgp
3. restart snmp
4. start bgp

Originally snmp subagent will crash.